### PR TITLE
canonical の誤りを修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -61,7 +61,7 @@ export default Vue.extend({
       link: [
         {
           rel: 'canonical',
-          href: `https://stopcovid19.yamanashi.dev/${this.$route.path}`
+          href: `https://stopcovid19.yamanashi.dev${this.$route.path}`
         }
       ]
     }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #37 

## ⛏ 変更内容 / Details of Changes
- canonical の誤りを修正
  - `/`は重ねず、`href="https://stopcovid19.yamanashi.dev/"`となるようにした

## 📸 スクリーンショット / Screenshots
<img width="640" alt="スクリーンショット 2020-04-01 18 37 18" src="https://user-images.githubusercontent.com/2931035/78123447-21fec200-7449-11ea-8539-f89b1e5ccbd2.png">
