### PR TITLE
flowページ 「新型コロナ 受診相談窓口」のリンク切れを修正

### DIFF
--- a/components/DesktopFlowSvg.vue
+++ b/components/DesktopFlowSvg.vue
@@ -1179,7 +1179,7 @@
       <g transform="translate(0 -19)">
         <g transform="translate(19 5)">
           <a
-            xlink:href="https://www.pref.yamanashi.jp/koucho/coronavirus/info_coronavirus.html#soudanmadoguchi"
+            xlink:href="https://www.pref.yamanashi.jp/koucho/coronavirus/info_coronavirus_consultation.html#Covid19_HealthConsultation"
             target="_blank"
             rel="noopener"
           >

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -110,7 +110,7 @@
               <dd>
                 <a
                   class="Link"
-                  href="https://www.pref.yamanashi.jp/koucho/coronavirus/info_coronavirus.html#soudanmadoguchi"
+                  href="https://www.pref.yamanashi.jp/koucho/coronavirus/info_coronavirus_consultation.html#Covid19_HealthConsultation"
                   target="_blank"
                   rel="noopener"
                 >
@@ -195,7 +195,7 @@
         </div>
       </div>
       <a
-        href="https://www.pref.yamanashi.jp/koucho/coronavirus/info_coronavirus.html#soudanmadoguchi"
+        href="https://www.pref.yamanashi.jp/koucho/coronavirus/info_coronavirus_consultation.html#Covid19_HealthConsultation"
         target="_blank"
         rel="noopener"
         class="Flow-Card-Button"
@@ -244,7 +244,7 @@ export default {
       margin-left: 8px;
       @include lessThan($medium) {
         @include font-size(20);
-        margin-right: .5em;
+        margin-right: 0.5em;
         line-height: 1.35;
       }
     }


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #40

## ⛏ 変更内容 / Details of Changes
- [「新型コロナウイルス感染症が心配なときに」](https://stopcovid19.yamanashi.dev/flow) ページ
  - 「新型コロナ 受診相談窓口」のリンク切れを修正
  - ESLint エラーを修正

## 📸 スクリーンショット / Screenshots
![localhost_3000_flow_(iPhone 6_7_8)](https://user-images.githubusercontent.com/2931035/78736815-09326700-7989-11ea-9eaf-e45bb9aeac20.png)
![www pref yamanashi jp_koucho_coronavirus_info_coronavirus_consultation html(iPhone 6_7_8)](https://user-images.githubusercontent.com/2931035/78736819-0b94c100-7989-11ea-9958-10c4a635d0bc.png)
