### PR TITLE
「陽性患者の属性」から「退院」を削除

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -13,9 +13,6 @@
       :mobile-breakpoint="0"
       class="cardTable"
     />
-    <div class="note">
-      ※退院には、死亡退院を含む
-    </div>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="info.lText"

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -4,8 +4,7 @@ const headers = [
   { text: '日付', value: '日付' },
   { text: '居住地', value: '居住地' },
   { text: '年代', value: '年代' },
-  { text: '性別', value: '性別' },
-  { text: '退院※', value: '退院', align: 'center' }
+  { text: '性別', value: '性別' }
 ]
 
 type DataType = {
@@ -13,7 +12,6 @@ type DataType = {
   居住地: string | null
   年代: string | null
   性別: '男性' | '女性'
-  退院: '◯' | null
   [key: string]: any
 }
 
@@ -22,7 +20,6 @@ type TableDataType = {
   居住地: DataType['居住地']
   年代: DataType['年代']
   性別: DataType['性別'] | '不明'
-  退院: DataType['退院']
 }
 
 type TableDateType = {
@@ -40,8 +37,7 @@ export default (data: DataType[]) => {
       日付: dayjs(d['リリース日']).format('MM/DD') ?? '不明',
       居住地: d['居住地'] ?? '不明',
       年代: d['年代'] ?? '不明',
-      性別: d['性別'] ?? '不明',
-      退院: d['退院']
+      性別: d['性別'] ?? '不明'
     }
     tableDate.datasets.push(TableRow)
   })


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #46 

## ⛏ 変更内容 / Details of Changes
- 「陽性患者の属性」から「退院」列を削除
- 「※退院には、死亡退院を含む」を削除

## 📸 スクリーンショット / Screenshots
### 変更前
<img width="572" alt="スクリーンショット 2020-05-04 03 31 48" src="https://user-images.githubusercontent.com/2931035/80922444-260b6000-8db8-11ea-9fac-aec652a7b862.png">

### 変更後
<img width="575" alt="スクリーンショット 2020-05-04 03 31 34" src="https://user-images.githubusercontent.com/2931035/80922458-33284f00-8db8-11ea-9919-13ce306432da.png">
