### PR TITLE
fix get data.json from master repository to main repository

### DIFF
--- a/.github/workflows/dataupdate.yml
+++ b/.github/workflows/dataupdate.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Copy data.json
-        run: curl -o data/data.json https://raw.githubusercontent.com/daisuke19891023/covid19-yamanashi-scraping/master/data.json
+        run: curl -o data/data.json https://raw.githubusercontent.com/daisuke19891023/covid19-yamanashi-scraping/main/data.json
       
       - name: Commit files
         run: |


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #184 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- data.jsonの取得先をスクレイピングツールのmasterレポジトリからmainレポジトリに変更
- 変更後のyamlにて取得可能なdata.jsonは以下のコマンドにより確認可能
`curl -o data/data.json https://raw.githubusercontent.com/daisuke19891023/covid19-yamanashi-scraping/main/data.json`

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
